### PR TITLE
bugfix: create long-lived connection && remove tabs premission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
 			"matches": ["https://chat.openai.com/*"]
 		}
 	],
-	"permissions": ["tabs", "activeTab", "storage"],
+	"permissions": ["storage"],
 	"description": "Save last errored chatgpt prompt",
 	"icons": {
 		"16": "assets/icon-16.png",


### PR DESCRIPTION
This PR solves the following issue: #1 

Explanation:

Using port connect a long-lived connection is made, solving the connection timeout issue.

Port connect allows the extension to work without `tabs` and `activeTab` permissions.